### PR TITLE
Fix out of bounds error in get_action_icon

### DIFF
--- a/addons/prompt_formatters/kenneys/prompt_kenneys_formatter.gd
+++ b/addons/prompt_formatters/kenneys/prompt_kenneys_formatter.gd
@@ -30,7 +30,7 @@ func format_async(game_control: GameControl) -> String:
 
 func get_action_icon(input_action : String) -> Texture:
 	var input_events = InputMap.action_get_events(input_action)
-	var input_event_index = min(Input.get_connected_joypads().size(), input_events.size())
+	var input_event_index = min(Input.get_connected_joypads().size(), input_events.size() - 1)
 	var icon = InputIconMapperGlobal.get_icon(input_events[input_event_index]) as Texture
 	if not icon:
 		icon = InputIconMapperGlobal.get_icon(input_events[0]) as Texture


### PR DESCRIPTION
Hovering on the bean objects caused the game to crash: PromptKenneysFormatter.get_action_icon: Invalid access of index '1' on a base object of type: 'Array[InputEvent]'. This fixes the indexing issue